### PR TITLE
Don't use ES6 features

### DIFF
--- a/loaders/elm.js
+++ b/loaders/elm.js
@@ -5,7 +5,7 @@ var exec = require('child_process').execSync;
 
 module.exports = function(source) {
   this.cacheable();
-  exec(`elm-make --output=elm.js ${this.resourcePath}`, function (error, stdout, stderr) {
+  exec("elm-make --output=elm.js " + this.resourcePath, function (error, stdout, stderr) {
     if (error !== null) {
       console.log('exec error: ' + error);
     }


### PR DESCRIPTION
This doesn't work without Babel, and since this is the only ES6 feature that seems to be used it seemed easier to just do this than try to figure out how to get everything setup with Babel.
